### PR TITLE
Constrain includes by running cargo-diet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ readme = "README.md"
 license = "MIT"
 
 edition = "2018"
+include = ["src/lib.rs", "LICENSE", "README.md"]


### PR DESCRIPTION
`cargo-diet` report:
```
┌─────────────────────────────────────┬─────────────┐
│ File                                │ Size (Byte) │
├─────────────────────────────────────┼─────────────┤
│ .gitignore                          │          21 │
│ examples/01_string_error.rs         │         217 │
│ .travis.yml                         │         230 │
│ examples/03_multiple_error_types.rs │         392 │
│ examples/02_custom_error.rs         │         657 │
└─────────────────────────────────────┴─────────────┘
Saved 16% or 1.5 KB in 5 files (of 9.2 KB and 9 files in entire crate)
```